### PR TITLE
Clarifying work directory for `bazel build`.

### DIFF
--- a/native_client/README.md
+++ b/native_client/README.md
@@ -69,11 +69,13 @@ ln -s ../DeepSpeech/native_client ./
 
 Before building the DeepSpeech client libraries, you will need to prepare your environment to configure and build TensorFlow. Follow the [instructions](https://www.tensorflow.org/install/install_sources) on the TensorFlow site for your platform, up to the end of 'Configure the installation'.
 
-Then you can build the Tensorflow and DeepSpeech libraries.
+Then you can build the Tensorflow and DeepSpeech libraries from within the `tensorflow` checkout root directory. 
 
 ```
 bazel build -c opt --copt=-O3 //tensorflow:libtensorflow_cc.so //tensorflow:libtensorflow_framework.so //native_client:deepspeech //native_client:deepspeech_utils //native_client:libctc_decoder_with_kenlm.so //native_client:generate_trie
 ```
+
+The above works, because the TensorFlow root contains the symbolic link to `native_client` you created during “Preparation”.
 
 Finally, you can change to the `native_client` directory and use the `Makefile`. By default, the `Makefile` will assume there is a TensorFlow checkout in a directory above the DeepSpeech checkout. If that is not the case, set the environment variable `TFDIR` to point to the right directory.
 


### PR DESCRIPTION
This call needs to be from within the TensorFlow checkout.